### PR TITLE
Normalize omniauth attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+
+## Auth Hash
+
+Here's an example hash available in `request.env['omniauth.auth']`
+
+```ruby
+{
+  provider: 'latvija',
+  uid: 'JANIS BERZINS, 12345612345',
+  info: {
+    name: 'JANIS BERZINS',
+    first_name: 'JANIS',
+    last_name: 'BERZINS',
+    private_personal_identifier: '12345612345'
+  },
+  extra: {
+    raw_info: {
+      name: 'JANIS BERZINS',
+      first_name: 'JANIS',
+      last_name: 'BERZINS',
+      private_personal_identifier: '12345612345'
+    },
+    authentication_method: 'SWEDBANK'
+  }
+}
+```
+
 ## References
 
 * http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html

--- a/lib/omniauth/strategies/latvija.rb
+++ b/lib/omniauth/strategies/latvija.rb
@@ -67,14 +67,16 @@ module OmniAuth::Strategies
     def auth_hash
       OmniAuth::Utils.deep_merge(super,
         uid: "#{@response.attributes['givenname']} #{@response.attributes['surname']}, #{@response.attributes["privatepersonalidentifier"]}",
-        user_info: {
+        info: {
           name: "#{@response.attributes['givenname']} #{@response.attributes['surname']}",
           first_name: @response.attributes['givenname'],
           last_name: @response.attributes['surname'],
           private_personal_identifier: @response.attributes['privatepersonalidentifier']
         },
         authentication_method: @response.authentication_method,
-        extra: @response.attributes
+        extra: {
+          raw_info: @response.attributes
+        }
       )
     end
   end

--- a/lib/omniauth/strategies/latvija.rb
+++ b/lib/omniauth/strategies/latvija.rb
@@ -34,6 +34,24 @@ module OmniAuth::Strategies
     option :certificate, nil
     option :private_key, nil
 
+    uid { "#{raw_info['givenname']} #{raw_info['surname']}, #{raw_info["privatepersonalidentifier"]}" }
+
+    info do
+      {
+        name: "#{raw_info['givenname']} #{raw_info['surname']}",
+        first_name: raw_info['givenname'],
+        last_name: raw_info['surname'],
+        private_personal_identifier: raw_info['privatepersonalidentifier']
+      }
+    end
+
+    extra do
+      {
+        raw_info: raw_info,
+        authentication_method: @response.authentication_method
+      }
+    end
+
     def request_phase
       params = {
         wa: 'wsignin1.0',
@@ -64,20 +82,8 @@ module OmniAuth::Strategies
       fail!(:invalid_response, e)
     end
 
-    def auth_hash
-      OmniAuth::Utils.deep_merge(super,
-        uid: "#{@response.attributes['givenname']} #{@response.attributes['surname']}, #{@response.attributes["privatepersonalidentifier"]}",
-        info: {
-          name: "#{@response.attributes['givenname']} #{@response.attributes['surname']}",
-          first_name: @response.attributes['givenname'],
-          last_name: @response.attributes['surname'],
-          private_personal_identifier: @response.attributes['privatepersonalidentifier']
-        },
-        authentication_method: @response.authentication_method,
-        extra: {
-          raw_info: @response.attributes
-        }
-      )
+    def raw_info
+      @response.attributes
     end
   end
 end

--- a/spec/omniauth/strategies/latvija_spec.rb
+++ b/spec/omniauth/strategies/latvija_spec.rb
@@ -34,9 +34,9 @@ describe OmniAuth::Strategies::Latvija, :type => :strategy do
       # puts "omniauth.strategy: #{last_request.env['omniauth.strategy'].inspect}"
 
       last_request.env['omniauth.error'].should be_nil
-      last_request.env['omniauth.auth']['user_info']['first_name'].should be_present
-      last_request.env['omniauth.auth']['user_info']['last_name'].should be_present
-      last_request.env['omniauth.auth']['user_info']['private_personal_identifier'].should be_present
+      last_request.env['omniauth.auth']['info']['first_name'].should be_present
+      last_request.env['omniauth.auth']['info']['last_name'].should be_present
+      last_request.env['omniauth.auth']['info']['private_personal_identifier'].should be_present
     end
 
     it 'should fail after unsuccessful authentication with fingerprint mismatch' do

--- a/spec/omniauth/strategies/latvija_spec.rb
+++ b/spec/omniauth/strategies/latvija_spec.rb
@@ -34,6 +34,8 @@ describe OmniAuth::Strategies::Latvija, :type => :strategy do
       # puts "omniauth.strategy: #{last_request.env['omniauth.strategy'].inspect}"
 
       last_request.env['omniauth.error'].should be_nil
+      last_request.env['omniauth.auth']['uid'].should be_present
+      last_request.env['omniauth.auth']['extra']['raw_info']['first_name'].should be_present
       last_request.env['omniauth.auth']['info']['first_name'].should be_present
       last_request.env['omniauth.auth']['info']['last_name'].should be_present
       last_request.env['omniauth.auth']['info']['private_personal_identifier'].should be_present


### PR DESCRIPTION
Change omniauth attribute key names to be similar to other strategies:

user_info -> info

extra: { all attributes } -> extra: { raw_info: { all attributes } } 

Example taken from https://github.com/mkdynamic/omniauth-facebook